### PR TITLE
GTM32_103_V1 config file

### DIFF
--- a/controllers/gtm32_103_v1/steppers.cfg
+++ b/controllers/gtm32_103_v1/steppers.cfg
@@ -1,4 +1,4 @@
-[extruder_stepper 3ms1]
+[extruder_stepper 3ms0]
 extruder: extruder
 step_pin: 3ms: PA11
 dir_pin: 3ms: PA12
@@ -7,7 +7,7 @@ microsteps: 16
 rotation_distance: 7.418
 full_steps_per_rotation: 200
 
-[extruder_stepper 3ms2]
+[extruder_stepper 3ms1]
 extruder: extruder
 step_pin: 3ms: PD15
 dir_pin: 3ms: PD3
@@ -16,7 +16,7 @@ microsteps: 16
 rotation_distance: 7.418
 full_steps_per_rotation: 200
 
-[extruder_stepper 3ms3]
+[extruder_stepper 3ms2]
 extruder: extruder
 step_pin: 3ms: PD6
 dir_pin: 3ms: PD7
@@ -25,7 +25,7 @@ microsteps: 16
 rotation_distance: 7.418
 full_steps_per_rotation: 200
 
-[extruder_stepper 3ms4]
+[extruder_stepper 3ms3]
 extruder: extruder
 step_pin: 3ms: PB5
 dir_pin: 3ms: PB6
@@ -34,7 +34,7 @@ microsteps: 16
 rotation_distance: 7.418
 full_steps_per_rotation: 200
 
-[extruder_stepper 3ms5] 
+[extruder_stepper 3ms4] 
 step_pin: 3ms: PB9
 dir_pin: 3ms: PE0
 enable_pin: !3ms: PB8
@@ -43,7 +43,7 @@ rotation_distance: 7.319
 full_steps_per_rotation: 200
 extruder: extruder
 
-[extruder_stepper 3ms6]
+[extruder_stepper 3ms5]
 step_pin: 3ms: PE4
 dir_pin: 3ms: PE5
 enable_pin: !3ms: PE3
@@ -52,7 +52,7 @@ rotation_distance: 7.331
 full_steps_per_rotation: 200
 extruder: extruder
 
-[extruder_stepper 3ms7]
+[extruder_stepper 3ms6]
 step_pin: 3ms: PC14
 dir_pin: 3ms: PC15
 enable_pin: !3ms: PC13

--- a/controllers/gtm32_103_v1/steppers.cfg
+++ b/controllers/gtm32_103_v1/steppers.cfg
@@ -1,0 +1,65 @@
+[extruder_stepper 3ms1]
+extruder: extruder
+step_pin: 3ms: PA11
+dir_pin: 3ms: PA12
+enable_pin: !3ms: PA8
+microsteps: 16
+rotation_distance: 7.418
+full_steps_per_rotation: 200
+
+[extruder_stepper 3ms2]
+extruder: extruder
+step_pin: 3ms: PD15
+dir_pin: 3ms: PD3
+enable_pin: !3ms: PD14
+microsteps: 16
+rotation_distance: 7.418
+full_steps_per_rotation: 200
+
+[extruder_stepper 3ms3]
+extruder: extruder
+step_pin: 3ms: PD6
+dir_pin: 3ms: PD7
+enable_pin: !3ms: PD5
+microsteps: 16
+rotation_distance: 7.418
+full_steps_per_rotation: 200
+
+[extruder_stepper 3ms4]
+extruder: extruder
+step_pin: 3ms: PB5
+dir_pin: 3ms: PB6
+enable_pin: !3ms: PB4
+microsteps: 16
+rotation_distance: 7.418
+full_steps_per_rotation: 200
+
+[extruder_stepper 3ms5] 
+step_pin: 3ms: PB9
+dir_pin: 3ms: PE0
+enable_pin: !3ms: PB8
+microsteps: 16
+rotation_distance: 7.319
+full_steps_per_rotation: 200
+extruder: extruder
+
+[extruder_stepper 3ms6]
+step_pin: 3ms: PE4
+dir_pin: 3ms: PE5
+enable_pin: !3ms: PE3
+microsteps: 16
+rotation_distance: 7.331
+full_steps_per_rotation: 200
+extruder: extruder
+
+[extruder_stepper 3ms7]
+step_pin: 3ms: PC14
+dir_pin: 3ms: PC15
+enable_pin: !3ms: PC13
+microsteps: 16
+rotation_distance: 7.418
+full_steps_per_rotation: 200
+extruder: extruder
+
+[mcu 3ms]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0


### PR DESCRIPTION
Added GeeetechA30T motherboard.
Printer.cfg reference used 
https://github.com/TheThomasD/A30T-Klipper-Backup/blob/master/printer.cfg

Up to 7 motors, rotation_distance is setup for bmg extruder clone(included in the printer)